### PR TITLE
docs: Add note about apm vs apm-beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ In `package.json`:
 ```json
 {
   "release": {
-    "extends": "@semantic-release/apm-config"  
+    "extends": "@semantic-release/apm-config"
   }
 }
 ```
@@ -38,6 +38,15 @@ $ semantic-release -e @semantic-release/apm-config
 The `apm` command line has to be installed in your CI environment and available in the `PATH`.
 
 See the [Atom Package CI Scripts](https://github.com/atom/ci#atom-package-ci-scripts) documentation.
+
+_Note: If you are running multiple versions of Atom in CI (Stable + Beta),
+ensure that the `semantic-release` command is run on a build using the Stable
+channel of Atom as the Beta channel builds only provide `apm-beta`. If you are
+using [travis-deploy-once](https://github.com/semantic-release/travis-deploy-once)
+this can be achieved by setting the Stable channel build to be the last build
+to run, or by using the
+[`buildLeaderId`](https://github.com/semantic-release/travis-deploy-once#-b---buildleaderid)
+option._
 
 ### Atom authentication
 


### PR DESCRIPTION
Add a note clarifying that when using `travis-deploy-once` and multiple versions of Atom in your CI configuration, the Stable channel build needs to be the "last" one for `apm` to be available.

Fixes #7.