### PR TITLE
test: use published git docker image

### DIFF
--- a/test/helpers/gitbox.js
+++ b/test/helpers/gitbox.js
@@ -3,7 +3,7 @@ import getStream from 'get-stream';
 import pRetry from 'p-retry';
 import {initBareRepo, gitShallowClone} from './git-utils';
 
-const IMAGE = 'nmarus/docker-gitbox';
+const IMAGE = 'pvdlg/docker-gitbox';
 const SERVER_PORT = 80;
 const HOST_PORT = 2080;
 const SERVER_HOST = 'localhost';


### PR DESCRIPTION
https://hub.docker.com/r/nmarus/docker-gitbox/ disappeared from the Docker Hub. Using a fork.