### PR TITLE
fix: use at least semantic-release/npm@3.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@semantic-release/exec": "^2.2.0",
     "@semantic-release/git": "^4.0.0",
     "@semantic-release/github": "^4.2.11",
-    "@semantic-release/npm": "^3.2.0",
+    "@semantic-release/npm": "^3.2.2",
     "execa": "^0.10.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This version of the npm plugin includes a patch crucial to this config.

Fixes #34